### PR TITLE
refactor: change strategy of closing modal from backdrop; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-modal",
-  "version": "0.2.17",
+  "version": "0.2.18-a1",
   "description": "Modal component for Meson Form and other usages",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
原先的逻辑是 Modal 会截断事件冒泡, 避免 Modal 卡片上的点击触发 Backdrop 上的点击, 导致触发关闭. 这个操作比较粗暴, 影响到 Dropdown 那边监听全局点击做关闭操作了. 改了成探测 `event.target` 的方式.
