### PR TITLE
new design for confirm modal; alpha release

### DIFF
--- a/example/pages/demos/confirm.tsx
+++ b/example/pages/demos/confirm.tsx
@@ -10,7 +10,7 @@ let code = `
 let [ui, waitConfirmation] = useConfirmModal();
 
 let onClick = async () => {
-  let result = await waitConfirmation({ title: "TODO", description: "TODO" });
+  let result = await waitConfirmation({ type: "warning", description: "TODO" });
   console.log("result", result);
 }
 
@@ -43,7 +43,6 @@ let DemoConfirm: FC<{}> = (props) => {
               onClick={async () => {
                 setResult(null);
                 let result = await waitConfirmation({
-                  title: "确定要删除节点?",
                   text: "节点可能包含子节点, 包含子元素, 删除节点会一并删除所有内容.",
                 });
                 console.log("result", result);
@@ -54,19 +53,32 @@ let DemoConfirm: FC<{}> = (props) => {
             <Space width={8} />
             <span>Result: {result != null ? JSON.stringify(result) : "-"}</span>
             <DocSnippet code={code} />
-          </DocDemo>
 
-          <DocDemo title="No title">
             <JimoButton
               onClick={async () => {
                 setResult(null);
                 let result = await waitConfirmation({
+                  text: "很短的警告.",
+                });
+                console.log("result", result);
+                setResult(result);
+              }}
+              text={"Short Warning"}
+            ></JimoButton>
+          </DocDemo>
+
+          <DocDemo title="Error">
+            <JimoButton
+              onClick={async () => {
+                setResult(null);
+                let result = await waitConfirmation({
+                  type: "error",
                   text: "节点可能包含子节点, 包含子元素, 删除节点会一并删除所有内容.",
                 });
                 console.log("result", result);
                 setResult(result);
               }}
-              text={"Confirm"}
+              text={"Error to confirm"}
             ></JimoButton>
           </DocDemo>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-modal",
-  "version": "0.2.24",
+  "version": "0.3.0-a1",
   "description": "Modal component for Meson Form and other usages",
   "main": "lib/index.js",
   "scripts": {

--- a/src/confirm.tsx
+++ b/src/confirm.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useEffect } from "react";
 import { ReactNode, useState } from "react";
 import MesonModal from "./modal";
-import { rowParted, rowCenter, Space, column, expand, fullHeight } from "@jimengio/flex-styles";
+import { rowParted, rowCenter, Space, column, expand, fullHeight, center, row } from "@jimengio/flex-styles";
 import { JimoButton } from "@jimengio/jimo-basics";
 import { css, cx } from "emotion";
+import JimoIcon, { EJimoIcon } from "@jimengio/jimo-icons";
 
 let defaultButtonLocales = {
   cancel: "Cancel",
@@ -16,7 +17,7 @@ export let resetConfirmButtonLocales = (locales: { cancel: string; confirm: stri
 };
 
 interface IConfirmOptions {
-  title?: string;
+  type?: "warning" | "error";
   text: string;
   cancelText?: string;
   confirmText?: string;
@@ -27,7 +28,17 @@ export let useConfirmModal = (options?: IConfirmOptions) => {
   let resolveRef = useRef(null);
   let rejectRef = useRef(null);
   let promiseRef = useRef<Promise<boolean>>();
-  let [confirmOptions, setConfirmOptions] = useState(options || { text: "Sure?" });
+  let [confirmOptions, setConfirmOptions] = useState(options || ({ text: "Sure?" } as IConfirmOptions));
+
+  let renderIcon = () => {
+    switch (confirmOptions?.type) {
+      case "error":
+        return <JimoIcon name={EJimoIcon.crossEmbossed} className={cx(styleIcon, styleError)} />;
+      case "warning":
+      default:
+        return <JimoIcon name={EJimoIcon.warnEmbossed} className={cx(styleIcon, styleWarning)} />;
+    }
+  };
 
   let ui = (
     <MesonModal
@@ -35,39 +46,36 @@ export let useConfirmModal = (options?: IConfirmOptions) => {
       visible={showModal}
       onClose={() => setShowModal(false)}
       disableBackdropClose={true}
-      width={400}
+      width={440}
       renderContent={() => {
         return (
           <div className={cx(column, expand, styleCard)}>
-            <Space height={8} />
-            {confirmOptions.title ? (
-              <>
-                <div className={styleTitle}>{confirmOptions.title}</div>
-                <Space height={8} />
-              </>
-            ) : null}
-            <div className={cx(expand, styleDesc)}>{confirmOptions.text}</div>
             <Space height={16} />
-            <div className={rowParted}>
-              <span />
-              <div className={rowCenter}>
-                <JimoButton
-                  text={confirmOptions.cancelText || defaultButtonLocales.cancel}
-                  onClick={() => {
-                    resolveRef.current(false);
-                    setShowModal(false);
-                  }}
-                />
-                <Space width={8} />
-                <JimoButton
-                  text={confirmOptions.cancelText || defaultButtonLocales.confirm}
-                  fillColor
-                  onClick={() => {
-                    resolveRef.current(true);
-                    setShowModal(false);
-                  }}
-                />
+            <div className={cx(expand, center)}>
+              <div className={cx(row, styleContent)}>
+                {renderIcon()}
+                <div className={expand}>{confirmOptions.text}</div>
               </div>
+            </div>
+            <Space height={16} />
+            <div className={rowCenter}>
+              <JimoButton
+                canceling
+                text={confirmOptions.cancelText || defaultButtonLocales.cancel}
+                onClick={() => {
+                  resolveRef.current(false);
+                  setShowModal(false);
+                }}
+              />
+              <Space width={16} />
+              <JimoButton
+                text={confirmOptions.cancelText || defaultButtonLocales.confirm}
+                fillColor
+                onClick={() => {
+                  resolveRef.current(true);
+                  setShowModal(false);
+                }}
+              />
             </div>
           </div>
         );
@@ -77,7 +85,7 @@ export let useConfirmModal = (options?: IConfirmOptions) => {
 
   let waitConfirmation = (opts?: IConfirmOptions) => {
     if (opts) {
-      setConfirmOptions({ ...confirmOptions, title: opts.title, text: opts.text, confirmText: opts.confirmText, cancelText: opts.cancelText });
+      setConfirmOptions({ ...confirmOptions, type: opts.type, text: opts.text, confirmText: opts.confirmText, cancelText: opts.cancelText });
     }
     setShowModal(true);
     if (!showModal) {
@@ -96,14 +104,22 @@ let styleCard = css`
   padding: 16px;
 `;
 
-let styleTitle = css`
-  font-weight: bold;
-  font-size: 16px;
-  line-height: 24px;
-`;
-
-let styleDesc = css`
+let styleContent = css`
   font-size: 14px;
   line-height: 24px;
   color: hsl(0, 0%, 40%);
+`;
+
+let styleIcon = css`
+  font-size: 20px;
+  margin-right: 8px;
+  border-radius: 10px;
+`;
+
+let styleError = css`
+  color: hsla(357, 91%, 55%, 1);
+`;
+
+let styleWarning = css`
+  color: hsla(36, 100%, 69%, 1);
 `;


### PR DESCRIPTION
Previews http://fe.jimu.io/meson-modal/#/confirm .

Property `title` is removed, which is a breaking change. Starting `0.3.0` versions.
