### PR TITLE
fix: moving problem in Chrome stable cause by transforming flexbox ma…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-modal",
-  "version": "0.3.1-a3",
+  "version": "0.3.1-a4",
   "description": "Modal component for Meson Form and other usages",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-modal",
-  "version": "0.3.1-a2",
+  "version": "0.3.1-a3",
   "description": "Modal component for Meson Form and other usages",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-modal",
-  "version": "0.3.0",
+  "version": "0.3.1-a1",
   "description": "Modal component for Meson Form and other usages",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/meson-modal",
-  "version": "0.3.1-a1",
+  "version": "0.3.1-a2",
   "description": "Modal component for Meson Form and other usages",
   "main": "lib/index.js",
   "scripts": {

--- a/src/confirm.tsx
+++ b/src/confirm.tsx
@@ -69,7 +69,7 @@ export let useConfirmModal = (options?: IConfirmOptions) => {
               />
               <Space width={16} />
               <JimoButton
-                text={confirmOptions.cancelText || defaultButtonLocales.confirm}
+                text={confirmOptions.confirmText || defaultButtonLocales.confirm}
                 fillColor
                 onClick={() => {
                   resolveRef.current(true);

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -235,6 +235,7 @@ let styleHeader = css`
   font-size: 16px;
   font-weight: bold;
   border-bottom: 1px solid hsl(0, 0%, 91%);
+  color: hsla(0, 0%, 0%, 0.85);
 `;
 
 let styleMoving = css`

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -130,14 +130,13 @@ let MesonModal: FC<{
     <div className={styleAnimations}>
       <CSSTransition in={props.visible} unmountOnExit={true} classNames="backdrop" timeout={transitionDuration}>
         <div className={styleBackdrop} onClick={onBackdropClick} ref={backdropElement}>
-          <div className={styleMoveContainer}>
+          <div className={styleMoveContainer} style={{ transform: `translate(${translation.x}px, ${translation.y}px)`, opacity: 1 - 0.01 * Math.random() }}>
             <div
               className={cx(column, stylePopPage, props.cardClassName, "modal-card")}
               style={{
                 maxHeight: window.innerHeight - 80,
                 width: props.width,
                 minWidth: props.width,
-                transform: `translate(${translation.x}px, ${translation.y}px)`,
               }}
               ref={cardRef}
             >

--- a/src/modal.tsx
+++ b/src/modal.tsx
@@ -130,10 +130,15 @@ let MesonModal: FC<{
     <div className={styleAnimations}>
       <CSSTransition in={props.visible} unmountOnExit={true} classNames="backdrop" timeout={transitionDuration}>
         <div className={styleBackdrop} onClick={onBackdropClick} ref={backdropElement}>
-          <div className={styleMoveContainer} style={{ transform: `translate(${translation.x}px, ${translation.y}px)` }}>
+          <div className={styleMoveContainer}>
             <div
               className={cx(column, stylePopPage, props.cardClassName, "modal-card")}
-              style={{ maxHeight: window.innerHeight - 80, width: props.width, minWidth: props.width }}
+              style={{
+                maxHeight: window.innerHeight - 80,
+                width: props.width,
+                minWidth: props.width,
+                transform: `translate(${translation.x}px, ${translation.y}px)`,
+              }}
               ref={cardRef}
             >
               {props.title ? (


### PR DESCRIPTION
…rgin:auto div

大致的问题是同一个因素上存在 `margin: auto` 跟 `transform: translate(...)` 的时候, 实际观察发现 Chrome Stable 没有随着 `transform` 更新而刷新界面. 这个代码再 Chrome Canary 当中却是可以正常运行的. 怀疑是 https://bugs.chromium.org/p/chromium/issues/detail?id=1007026 . 不过同样问题在 Safari 跟 Firefox 同样出现.

当前 PR 的做法是加上一个接近于 1 的随机的 `opacity` 强制界面进行重绘.